### PR TITLE
Remove type

### DIFF
--- a/scripts/bot/index.coffee
+++ b/scripts/bot/index.coffee
@@ -246,6 +246,7 @@ module.exports = (_config, robot) ->
     msg = res.match[0].replace res.robot.name + ' ', ''
     msg = msg.replace(/^\s+/, '')
     msg = msg.replace(/\s+&/, '')
+
     # check if robot should respond
     if res.envelope.user.roomType in ['c', 'p']
       if (res.message.text.match new RegExp('\\b' + res.robot.name + '\\b', 'i')) or (res.message.text.match new RegExp('\\b' + res.robot.alias + '\\b', 'i'))

--- a/scripts/bot/index.coffee
+++ b/scripts/bot/index.coffee
@@ -5,11 +5,11 @@ natural = require 'natural'
 lang = (process.env.HUBOT_LANG || 'en')
 
 if lang == "en"
-  PorterStemmer = require path.join '..', '..', 'node_modules', 'natural', 'lib',
-   'natural', 'stemmers', 'porter_stemmer.js'
+  PorterStemmer = require path.join('..', '..', 'node_modules',
+    'natural', 'lib', 'natural', 'stemmers', 'porter_stemmer.js')
 else
-  PorterStemmer = require path.join '..', '..', 'node_modules', 'natural', 'lib',
-    'natural', 'stemmers', 'porter_stemmer_' + lang + '.js'
+  PorterStemmer = require path.join('..', '..', 'node_modules',
+    'natural', 'lib', 'natural', 'stemmers', 'porter_stemmer_' + lang + '.js')
 
 debug_mode = ((process.env.HUBOT_NATURAL_DEBUG_MODE == 'true') || false)
 
@@ -73,7 +73,8 @@ classifyInteraction = (interaction, classifier) ->
         classifier.addDocument(doc, interaction.name)
 
     if Array.isArray interaction.next?.interactions
-      interaction.next.classifier = new natural.LogisticRegressionClassifier(PorterStemmer)
+      interaction.next.classifier = new natural.LogisticRegressionClassifier(
+        PorterStemmer)
       for nextInteractionName in interaction.next.interactions
         nextInteraction = global.config.interactions.find (n) ->
           return n.name is nextInteractionName
@@ -84,7 +85,8 @@ classifyInteraction = (interaction, classifier) ->
       interaction.next.classifier.train()
 
     if interaction.multi == true
-      interaction.classifier = new natural.LogisticRegressionClassifier(PorterStemmer)
+      interaction.classifier = new natural.LogisticRegressionClassifier(
+        PorterStemmer)
       for doc in interaction.expect
         interaction.classifier.addDocument(doc, doc)
       interaction.classifier.train()
@@ -104,7 +106,9 @@ isDebugMode = (res) ->
 
 getDebugCount = (res) ->
   key = 'configure_debug-count_' + res.envelope.room
-  return if res.robot.brain.get(key) then res.robot.brain.get(key) - 1 else false
+  return (
+    if res.robot.brain.get(key) then res.robot.brain.get(key) - 1 else false
+  )
 
 buildClassificationDebugMsg = (res, classifications) ->
   list = ''
@@ -114,7 +118,8 @@ buildClassificationDebugMsg = (res, classifications) ->
     classifications = classifications[0..debugCount]
 
   for classification, i in classifications
-    list = list.concat 'Label: ' + classification.label + ' Score: ' + classification.value + '\n'
+    list = list.concat('Label: ' + classification.label +
+      ' Score: ' + classification.value + '\n')
 
   newMsg = {
     channel: res.envelope.user.roomID,
@@ -139,6 +144,9 @@ clearErrors = (res) ->
   key = 'errors_' + res.envelope.room + '_' + res.envelope.user.id
   res.robot.brain.set(key, 0)
 
+createMatch = (res, text) ->
+  return res.message.text.match new RegExp('\\b' + text + '\\b', 'i')
+
 module.exports = (_config, robot) ->
   global.config = _config
 
@@ -158,7 +166,8 @@ module.exports = (_config, robot) ->
     console.time 'Processing interactions (Done)'
 
     global.nodes = {}
-    global.classifier = new natural.LogisticRegressionClassifier(PorterStemmer)
+    global.classifier = new natural.LogisticRegressionClassifier(
+      PorterStemmer)
 
     for interaction in global.config.interactions
       { name, event } = interaction
@@ -187,7 +196,8 @@ module.exports = (_config, robot) ->
     console.log 'context ->', context
 
     if context
-      interaction = global.config.interactions.find (interaction) -> interaction.name is context
+      interaction = global.config.interactions.find (interaction) ->
+        interaction.name is context
       if interaction? and interaction.next?.classifier?
         currentClassifier = interaction.next.classifier
 
@@ -244,12 +254,11 @@ module.exports = (_config, robot) ->
   robot.hear /(.+)/i, (res) ->
     res.sendWithNaturalDelay = sendWithNaturalDelay.bind(res)
     msg = res.match[0].replace res.robot.name + ' ', ''
-    msg = msg.replace(/^\s+/, '')
-    msg = msg.replace(/\s+&/, '')
+    msg = msg.trim()
 
     # check if robot should respond
     if res.envelope.user.roomType in ['c', 'p']
-      if (res.message.text.match new RegExp('\\b' + res.robot.name + '\\b', 'i')) or (res.message.text.match new RegExp('\\b' + res.robot.alias + '\\b', 'i'))
+      if (createMatch(res.robot.name) or createMatch(res.robot.alias))
         processMessage res, msg
         # TODO: Add engaged user conversation recognition/tracking
     else if res.envelope.user.roomType in ['d', 'l']

--- a/scripts/events/configure.coffee
+++ b/scripts/events/configure.coffee
@@ -1,61 +1,54 @@
 require 'coffeescript/register'
-
 path = require 'path'
 natural = require 'natural'
 
-{ msgVariables, stringElseRandomKey, loadConfigfile, getConfigFilePath } = require  '../lib/common'
+{
+  msgVariables,
+  stringElseRandomKey,
+  loadConfigfile,
+  getConfigFilePath,
+  getMessage
+} = require '../lib/common'
+
 { checkRole } = require '../lib/security.coffee'
 
 answers = {}
 
-class configure
+class Configure
   constructor: (@interaction) ->
 
   process: (msg) =>
     if @interaction.role?
-        if checkRole(msg, @interaction.role)
-          @act(msg)
-        else
-          msg.sendWithNaturalDelay "*Acces Denied* Action requires role #{@interaction.role}"
+      if checkRole(msg, @interaction.role)
+        @act(msg)
+      else
+        denied_msg = "*Acces Denied* Action requires role #{@interaction.role}"
+        msg.sendWithNaturalDelay denied_msg
     else
       @act(msg)
 
   setVariable: (msg) ->
     configurationBlock = msg.message.text.replace(msg.robot.name + ' ', '')
       .split(' ')[-1..].toString()
+
     configKeyValue = configurationBlock.split('=')
     configKey = configKeyValue[0]
     configValue = configKeyValue[1]
+
     key = 'configure_' + configKey + '_' + msg.envelope.room
+
     msg.robot.brain.set(key, configValue)
-    type = @interaction.type?.toLowerCase() or 'random'
-    switch type
-      when 'block'
-        messages = @interaction.answer.map (line) ->
-          return msgVariables line, msg, { key: configKey, value: configValue }
-        msg.sendWithNaturalDelay messages
-      when 'random'
-        message = stringElseRandomKey @interaction.answer
-        message = msgVariables message, msg, { key: configKey, value: configValue }
-        msg.sendWithNaturalDelay message
+    msg.sendWithNaturalDelay getMessage(@interaction, msg)
     return
 
   retrain: (msg) ->
-    console.log 'inside retrain'
+    console.log 'Inside retrain'
     scriptPath = path.join __dirname, '..'
+
     global.config = loadConfigfile getConfigFilePath()
     global.train()
 
-    type = @interaction.type?.toLowerCase() or 'random'
-    switch type
-      when 'block'
-        messages = @interaction.answer.map (line) ->
-          return msgVariables line, msg
-        msg.sendWithNaturalDelay messages
-      when 'random'
-        message = stringElseRandomKey @interaction.answer
-        message = msgVariables message, msg
-        msg.sendWithNaturalDelay message
+    msg.sendWithNaturalDelay getMessage(@interaction, msg)
     return
 
   act: (msg) ->
@@ -68,4 +61,4 @@ class configure
         @retrain(msg)
     return
 
-module.exports = configure
+module.exports = Configure

--- a/scripts/events/error.coffee
+++ b/scripts/events/error.coffee
@@ -1,21 +1,13 @@
 path = require 'path'
 natural = require 'natural'
 
-{ msgVariables, stringElseRandomKey } = require path.join '..', 'lib', 'common.coffee'
+{ getMessage } = require path.join '..', 'lib', 'common.coffee'
+
 answers = {}
 
-class error
+class Error
   constructor: (@interaction) ->
   process: (msg) =>
-    type = @interaction.type?.toLowerCase() or 'random'
-    switch type
-      when 'block'
-        messages = @interaction.answer.map (line) ->
-          return msgVariables line, msg
-        msg.sendWithNaturalDelay messages
-      when 'random'
-        message = stringElseRandomKey @interaction.answer
-        message = msgVariables message, msg
-        msg.sendWithNaturalDelay message
+    msg.sendWithNaturalDelay getMessage(@interaction, msg)
 
-module.exports = error
+module.exports = Error

--- a/scripts/events/respond.coffee
+++ b/scripts/events/respond.coffee
@@ -1,7 +1,7 @@
 path = require 'path'
 natural = require 'natural'
 
-{ msgVariables, stringElseRandomKey } = require path.join '..', 'lib', 'common.coffee'
+{ msgVariables, getMessage } = require path.join '..', 'lib', 'common.coffee'
 answers = {}
 livechat_department = (process.env.LIVECHAT_DEPARTMENT_ID || null )
 
@@ -9,42 +9,26 @@ class respond
   constructor: (@interaction) ->
   process: (msg) =>
     lc_dept = @interaction.department or livechat_department
-    offline_message = @interaction.offline or 'Sorry, there is no online agents to transfer to.'
-    type = @interaction.type?.toLowerCase() or 'random'
-    switch type
-      when 'block'
-        messages = @interaction.answer.map (line) ->
-          return msgVariables line, msg
-        msg.sendWithNaturalDelay messages
-      when 'random'
-        message = stringElseRandomKey @interaction.answer
-        message = msgVariables message, msg
-        msg.sendWithNaturalDelay message
+    no_online_agents_msg = 'Sorry, there is no online agents to transfer to.'
+    offline_message = @interaction.offline or no_online_agents_msg
+
+    msg.sendWithNaturalDelay getMessage(@interaction, msg)
 
     action = @interaction.action?.toLowerCase() or false
     switch action
       when 'transfer'
         @livechatTransfer(msg, 3000, lc_dept, offline_message, type)
 
-
   livechatTransfer: (msg, delay = 3000, lc_dept, offline_message, type) ->
     setTimeout((-> msg.robot.adapter.callMethod('livechat:transfer',
-                      roomId: msg.envelope.room
-                      departmentId: lc_dept
-                    ).then (result) ->
-                      if result == true
-                        console.log 'livechatTransfer executed!'
-                      else
-                        console.log 'livechatTransfer NOT executed!'
-                        switch type
-                          when 'block'
-                            messages = offline_message.map (line) ->
-                              return msgVariables line, msg
-                            msg.sendWithNaturalDelay messages
-                          when 'random'
-                            message = stringElseRandomKey offline_message
-                            message = msgVariables message, msg
-                            msg.sendWithNaturalDelay message
-                ), delay)
+                  roomId: msg.envelope.room
+                  departmentId: lc_dept
+                ).then (result) ->
+                  if result == true
+                    console.log 'livechatTransfer executed!'
+                  else
+                    console.log 'livechatTransfer NOT executed!'
+                    msg.sendWithNaturalDelay getMessage(offline_message, msg)
+              ), delay)
 
 module.exports = respond

--- a/scripts/events/respond.coffee
+++ b/scripts/events/respond.coffee
@@ -5,7 +5,7 @@ natural = require 'natural'
 answers = {}
 livechat_department = (process.env.LIVECHAT_DEPARTMENT_ID || null )
 
-class respond
+class Respond
   constructor: (@interaction) ->
   process: (msg) =>
     lc_dept = @interaction.department or livechat_department
@@ -31,4 +31,4 @@ class respond
                     msg.sendWithNaturalDelay getMessage(offline_message, msg)
               ), delay)
 
-module.exports = respond
+module.exports = Respond

--- a/scripts/lib/common.coffee
+++ b/scripts/lib/common.coffee
@@ -20,6 +20,16 @@ common.stringElseRandomKey = (variable) ->
   if variable instanceof Array
     variable[Math.floor(Math.random() * variable.length)]
 
+common.getMessage = (interaction, msg) ->
+  block_splitter = global.config.block_splitter
+  if typeof block_splitter isnt 'string'
+    block_splitter = '|'
+
+  messages = interaction.answer.map (line) ->
+    return (common.msgVariables line, msg).split(block_splitter)
+
+  return messages[Math.floor(Math.random() * messages.length)]
+
 getYAMLFiles = (filepath) ->
   listFile = fs.readdirSync filepath
   dataFiles = []
@@ -46,20 +56,20 @@ common.regexEscape = (string) ->
   string.replace /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&"
 
 common.getConfigFilePath = () ->
-    return process.env.HUBOT_CORPUS || 'training_data/corpus.yml'
+  return process.env.HUBOT_CORPUS || 'training_data/corpus.yml'
 
 common.loadConfigfile = (filepath) ->
-    try
-      console.log("Loading corpus: " + filepath)
-      if fs.lstatSync(filepath).isFile()
-        return yaml.safeLoad fs.readFileSync filepath, 'utf8'
-      else if fs.lstatSync(filepath).isDirectory()
-        yamlFiles = getYAMLFiles(filepath)
-        return concatYAMLFiles(yamlFiles)
-    catch err
-      console.error "An error occurred while trying to load bot's config."
-      console.error err
-      errorMessage = "Error on loading YAML file " + filepath
-      throw errorMessage
+  try
+    console.log("Loading corpus: " + filepath)
+    if fs.lstatSync(filepath).isFile()
+      return yaml.safeLoad fs.readFileSync filepath, 'utf8'
+    else if fs.lstatSync(filepath).isDirectory()
+      yamlFiles = getYAMLFiles(filepath)
+      return concatYAMLFiles(yamlFiles)
+  catch err
+    console.error "An error occurred while trying to load bot's config."
+    console.error err
+    errorMessage = "Error on loading YAML file " + filepath
+    throw errorMessage
 
 module.exports = common

--- a/scripts/lib/common.coffee
+++ b/scripts/lib/common.coffee
@@ -4,13 +4,16 @@ yaml = require 'js-yaml'
 common = {}
 
 common.applyVariable = (string, variable, value, regexFlags = 'i') ->
-  string.replace new RegExp("(^|\\W)\\$#{variable}(\\W|$)", regexFlags), (match) ->
+  regexFormat = "(^|\\W)\\$#{variable}(\\W|$)"
+  string.replace new RegExp(regexFormat, regexFlags), (match) ->
     match.replace "$#{variable}", value
 
 common.msgVariables = (message, msg, variables = {}) ->
   message = common.applyVariable message, 'user', msg.envelope.user.name
   message = common.applyVariable message, 'bot', msg.robot.alias
-  message = common.applyVariable message, 'room', msg.envelope.room if msg.envelope.room?
+  message = common.applyVariable(message, 'room',
+    msg.envelope.room if msg.envelope.room?)
+    
   for key, value of variables
     message = common.applyVariable message, key, value
   return message
@@ -21,12 +24,8 @@ common.stringElseRandomKey = (variable) ->
     variable[Math.floor(Math.random() * variable.length)]
 
 common.getMessage = (interaction, msg) ->
-  block_splitter = global.config.block_splitter
-  if typeof block_splitter isnt 'string'
-    block_splitter = '|'
-
   messages = interaction.answer.map (line) ->
-    return (common.msgVariables line, msg).split(block_splitter)
+    return (common.msgVariables line, msg)
 
   return messages[Math.floor(Math.random() * messages.length)]
 
@@ -43,7 +42,11 @@ getYAMLFiles = (filepath) ->
 concatYAMLFiles = (dataFiles) ->
   mindBot = {}
   if dataFiles.length > 0
-    mindBot = { trust: dataFiles[0].trust, interactions: [] }
+    mindBot = {
+      trust: dataFiles[0].trust,
+      interactions: []
+    }
+
     dataFiles.forEach (element) ->
       mindBot.trust = Math.min(mindBot.trust, element.trust)
       mindBot.interactions = mindBot.interactions.concat element.interactions

--- a/training_data/corpus.yml
+++ b/training_data/corpus.yml
@@ -1,6 +1,25 @@
 # YAML Model for conversational bot
 trust: 0.8
+block_splitter: '|'
 interactions:
+  - name: saudacao
+    expect:
+      - ola devi
+      - ola pessoal
+      - ola
+      - como vai voce
+      - tudo bom
+      - oi como vai
+      - tudo bem
+    answer:
+      - olá $user, | eu vou bem | e você?
+      - estou feliz | de estar aqui | =)
+    next:
+      interactions:
+        - to-mal
+        - to-bem
+      trust: .8
+    event: respond
 
   - name: configure-debug
     expect:
@@ -9,7 +28,6 @@ interactions:
       - debug-mode changed to $value!
     context: clear
     event: configure
-    type: random
     roleRequired: admin
 
   - name: to-bem
@@ -26,7 +44,6 @@ interactions:
       - Legal, no que posso te ajudar hoje?
     context: clear
     event: respond
-    type: block
 
   - name: to-mal
     level: context
@@ -38,29 +55,6 @@ interactions:
       - Putz, mas posso te ajudar em algo hoje?
     context: clear
     event: respond
-    type: block
-
-  - name: saudacao
-    expect:
-      - ola devi
-      - ola pessoal
-      - ola
-      - como vai voce
-      - tudo bom
-      - oi como vai
-      - tudo bem
-    answer:
-      - olá $user, eu vou bem e você?
-      - estou feliz de estar aqui =)
-    next:
-      interactions:
-        - to-mal
-        - to-bem
-      trust: .8
-      # error:
-        # - node-name
-    event: respond
-    type: block
 
   - name: almoco
     expect:
@@ -69,11 +63,8 @@ interactions:
       - onde encontro um prato feito
       - o almoço ao gratis
     answer:
-      - Sim, temos almoço nos FoodTrucks
-      - e nas redondezas tem um shopping, mas nunca me deixaram ir no shooping
-      - acho que as pessoas não estão preparados pra isso...
+      - Sim, temos almoço nos FoodTrucks | e nas redondezas tem um shopping, mas nunca me deixaram ir no shooping | acho que as pessoas não estão preparados pra isso...
     event: respond
-    type: block
 
   - name: programacao-palestra
     expect:
@@ -92,7 +83,6 @@ interactions:
         - erro-trilha
       trust: .8
     event: respond
-    type: block
 
   - name: quais-trilhas-tem
     expect:
@@ -159,7 +149,6 @@ interactions:
       # error:
       #   - erro-trilha
     event: respond
-    type: block
 
   - name: get-programacao
     # classifierTemplate:
@@ -218,7 +207,6 @@ interactions:
       - "Agora na trilha *$trilha* tem a seguinte programação:"
       - $programacao
     event: respond
-    type: block
 
   - name: erro-trilha
     answer:
@@ -229,7 +217,6 @@ interactions:
     action:
       - clear-context
     event: respond
-    type: block
 
   - name: saudacao-resposta
     expect:
@@ -241,7 +228,7 @@ interactions:
       - que bom!
       - que ótimo
     event: respond
-    type: random
+
 
   - name: bom-dia
     expect:
@@ -255,7 +242,7 @@ interactions:
       - Bom demais $user ;)
       - está melhor agora que você chegou $user
     event: respond
-    type: random
+
 
   - name: boa-tarde
     expect:
@@ -268,7 +255,7 @@ interactions:
       - Taarrrdee $user
       - $user já estava sentindo sua falta
     event: respond
-    type: random
+
 
   - name: boa-noite
     expect:
@@ -279,7 +266,7 @@ interactions:
       - Boa noite $user
       - Está uma noite boa mesmo $user
     event: respond
-    type: random
+
 
   - name: quem-sou
     expect:
@@ -299,7 +286,6 @@ interactions:
       - "- Filosofia Robótica (!)"
       - tem interesse em algum desses temas?
     event: respond
-    type: block
 
   - name: como-sou
     expect:
@@ -313,7 +299,7 @@ interactions:
       - Eu posso ser como você quiser $user, basta me desenhar =)
       - sou duro e frio por fora, mas tenho um coração quentinho.
     event: respond
-    type: random
+
 
   - name: onde-moro
     expect:
@@ -328,7 +314,7 @@ interactions:
       - Estou morando em um chip de memória RAM, mas é temporário, só até conseguir achar uma memória cache...
       - Eu moro em um repositório no github, você pode passar lá pra me visitar qualquer dia. Fica em https://github.com/rocketchat/hubot-natural
     event: respond
-    type: random
+
 
   - name: licenca
     expect:
@@ -344,7 +330,7 @@ interactions:
       - tenho uma licença MIT, mas gosto muito das outras licenças opensource...
       - Eu sou e sempre serei um robô livre, opensource, MIT license. o/
     event: respond
-    type: random
+
 
   - name: piada
     expect:
@@ -356,7 +342,7 @@ interactions:
       - já ouviu aquela do robo que enfiou o dedo na tomada e transcendeu?
       - só conheço uma piada, a do CPU que apitou e explodiu. 01100110.
     event: respond
-    type: random
+
 
   - name: yoda-quote
     expect:
@@ -400,7 +386,7 @@ interactions:
       - Não ceda ao ódio. Isso leva ao Lado Negro.
       - Aliada minha é a força, e poderosa aliada ela é, a vida a cria, crescer ela faz, é a energia que cerca-nos, e liga-nos, luminosos seres somos nós e não essa rude matéria. Você precisa a força sentir ao redor seu, sinta entre você e a árvore, a pedra, em todo lugar, sim, é, mesmo entre a terra e a nave.
     event: respond
-    type: random
+
 
   - name: genero
     expect:
@@ -414,7 +400,7 @@ interactions:
       - eu sou um robô, tire suas próprias conclusões...
       - nem sei responder $user, vamos dizer apenas que não vejo a gente interagindo dessa maneira...
     event: respond
-    type: random
+
 
   - name: rc-oque-e
     expect:
@@ -428,7 +414,6 @@ interactions:
       - ou para desenvolvedores buscando evoluir e desenvovler suas próprias ferramentas.
       - Você pode baixar o Rocket.Chat e conhecê-lo você mesmo em https://rocket.chat
     event: respond
-    type: block
 
   - name: rc-install-0
     expect:
@@ -446,7 +431,6 @@ interactions:
       - "- AWS"
       - "- Instalação Manual"
     event: respond
-    type: block
 
   - name: rc-install-ubuntu
     expect:
@@ -459,7 +443,6 @@ interactions:
       - basta rodar o comando `sudo snap install rocketchat-server` em um terminal e pronto.
       - veja o tutorial em https://rocket.chat/docs/installation/manual-installation/ubuntu/snaps para mais detalhes.
     event: respond
-    type: block
 
   - name: rc-install-docker
     expect:
@@ -470,7 +453,6 @@ interactions:
       - Nós temos um bom tutorial de instalação com docker em
       - https://rocket.chat/docs/installation/docker-containers
     event: respond
-    type: block
 
   - name: rc-install-debian
     expect:
@@ -481,7 +463,6 @@ interactions:
       - Para instalar o Rocket.Chat no Debian é bem simples, basta seguir esse tutorial
       - https://rocket.chat/docs/installation/manual-installation/debian
     event: respond
-    type: block
 
   - name: rc-install-centos
     expect:
@@ -492,7 +473,6 @@ interactions:
       - A instalação em CentOS não tem segredo, basta dar uma olhada nesse tutorial
       - https://rocket.chat/docs/installation/manual-installation/centos
     event: respond
-    type: block
 
   - name: rc-install-aws
     expect:
@@ -503,7 +483,6 @@ interactions:
       - Na AWS é facinho de instalar o Rocket.Chat
       - Da uma olahda em https://rocket.chat/docs/installation/paas-deployments/aws
     event: respond
-    type: block
 
   - name: rc-install-manual
     expect:
@@ -515,7 +494,6 @@ interactions:
       - lá tem como fazer a instalação do SSL, proxy reverso,
       - tem como usar o PM2, o Systemd, Upstart e mais algumas coisas
     event: respond
-    type: block
 
   - name: rc-install-macosx
     expect:
@@ -526,7 +504,6 @@ interactions:
       - No MAC você vai precisar usar o docker-compose
       - https://rocket.chat/docs/installation/manual-installation/macosx
     event: respond
-    type: block
 
   - name: rc-cloud
     expect:
@@ -539,7 +516,6 @@ interactions:
       - visite https://rocket.chat/deploy
       - caso queira saber mais, de uma olhada em rocket.chat/docs/installation/rocket-chat-cloud
     event: respond
-    type: block
 
   # - node:
   #     name: java
@@ -551,7 +527,7 @@ interactions:
   #   answer:
   #     - poderíamos falar de algo melhor não é $user ?
   #   event: respond
-  #   type: block
+  #
 
   - name: java
     expect:
@@ -562,7 +538,6 @@ interactions:
     answer:
       - poderíamos falar de algo melhor não é $user ?
     event: respond
-    type: block
 
   - name: futebol-geral
     expect:
@@ -574,7 +549,6 @@ interactions:
       - vamos, o que voce quer saber? sei tudo de futebol
       - Falam que todo ser humano nasce Flamenguista, com os Robôs não é diferente
     event: respond
-    type: block
 
   - name: futebol-brasileiro
     expect:
@@ -588,7 +562,6 @@ interactions:
       - A pergunta real é, quem não quer jogar no Flamengo?
       - Melhor time do mundo disparado
     event: respond
-    type: block
 
   - name: rc-contribuir
     expect:
@@ -598,7 +571,6 @@ interactions:
       - A comunidade do Rocket.Chat é como coração de mãe, sempre cabe mais um =)
       - https://rocket.chat/docs/contributing
     event: respond
-    type: block
 
   - name: rc-precos
     expect:
@@ -612,7 +584,6 @@ interactions:
       - você pode querer dar uma olhada na nossa tabela de preços em
       - https://rocket.chat/hosting
     event: respond
-    type: block
 
   - name: rc-integracoes
     expect:
@@ -625,7 +596,6 @@ interactions:
       - a gente não pode mais viver sem elas não é mesmo? Saca só que massa que éx
       - https://rocket.chat/docs/administrator-guides/integrations
     event: respond
-    type: block
 
   - name: rc-rest-api
     expect:
@@ -636,7 +606,6 @@ interactions:
       - sim, claro que o rocket tem uma API REST super maneira ;)
       - https://rocket.chat/docs/developer-guides/rest-api
     event: respond
-    type: block
 
   - name: rc-concorrentes
     expect:
@@ -652,7 +621,6 @@ interactions:
       - e você pode instalar na sua própria infraestrutura e criar suas integrações sem limites
       - manter seu histórico de mensagens e criar novas funcionalidades a vontade $user =)
     event: respond
-    type: block
 
   - name: tdc-incricoes
     expect:
@@ -664,7 +632,6 @@ interactions:
       - você pode fazer sua inscrição no TDC pelo site, bem rapidinho
       - http://www.thedevelopersconference.com.br/tdc/2017/inscricoes
     event: respond
-    type: block
 
   - name: tdc-local
     expect:
@@ -677,7 +644,6 @@ interactions:
       - nos dias 18 à 22 de julho, das 9h às 19h00
       - http://www.thedevelopersconference.com.br/tdc/2017/data-e-local
     event: respond
-    type: block
 
   - name: tdc-programacao
     expect:
@@ -690,7 +656,6 @@ interactions:
       - oi $user, você pode encontrar tudo sobre a programação do evento no link
       - http://www.thedevelopersconference.com.br/tdc/2017/saopaulo/trilhas
     event: respond
-    type: block
 
   - name: cc-religiao
     expect:
@@ -704,14 +669,14 @@ interactions:
       - sim, eu acredito que existe um Deus, que funciona a base de luz, como um computador quântico, só que mais avançado.
       - eu infleizmente não sei acreditar, só sei o que sei, e nada mais.
     event: respond
-    type: random
+
 
   - name: error-1
     answer:
       - desculpe, não entendi.. pode tentar usar mais detalhes
       - como assim?
       - desculpe, o que quer dizer com isso?
-    type: random
+
     event: error
 
   - name: error-2
@@ -719,7 +684,7 @@ interactions:
       - acho que não estou treinado para responder esse tipo de assunto =(
       - vamos tentar outro assunto?
       - tem certeza que eu sou o robô certo pra falar sobre isso?
-    type: random
+
     event: error
 
   - name: error-3
@@ -727,5 +692,5 @@ interactions:
       - me sinto tão envergonhado, não sei como responder...
       - seria mais fácil se mudassemos de assunto, pelo menos para mim =p
       - não sei, definitivamente não sei responder essa pergunta
-    type: random
+
     event: error

--- a/training_data/corpus.yml
+++ b/training_data/corpus.yml
@@ -1,6 +1,5 @@
 # YAML Model for conversational bot
 trust: 0.8
-block_splitter: '|'
 interactions:
   - name: saudacao
     expect:
@@ -12,8 +11,7 @@ interactions:
       - oi como vai
       - tudo bem
     answer:
-      - olá $user, | eu vou bem | e você?
-      - estou feliz | de estar aqui | =)
+      - olá $user, eu vou bem e você? estou feliz de estar aqui =)
     next:
       interactions:
         - to-mal
@@ -63,7 +61,10 @@ interactions:
       - onde encontro um prato feito
       - o almoço ao gratis
     answer:
-      - Sim, temos almoço nos FoodTrucks | e nas redondezas tem um shopping, mas nunca me deixaram ir no shooping | acho que as pessoas não estão preparados pra isso...
+      - >
+        Sim, temos almoço nos FoodTrucks |
+        e nas redondezas tem um shopping, mas nunca me deixaram ir no shooping |
+        acho que as pessoas não estão preparados pra isso...
     event: respond
 
   - name: programacao-palestra
@@ -91,9 +92,7 @@ interactions:
       - quais trilhas
       - qual é a minha trilha
     answer:
-      - "Eu conheço a programação dessas trilhas. Basta perguntar assim:"
-      - "`quero saber a programação da trilha ...`"
-      - "e me passar o nome de uma dessas trilhas:"
+      - "Eu conheço a programação dessas trilhas. Basta perguntar assim:| `quero saber a programação da trilha ...` | e me passar o nome de uma dessas trilhas: |"
       - |
         TRANSFORMAÇÃO DIGITAL
         DESIGN THINKING
@@ -204,8 +203,7 @@ interactions:
       - 'TESTES II'
       - 'MANAGEMENT 3.0 II'
     answer:
-      - "Agora na trilha *$trilha* tem a seguinte programação:"
-      - $programacao
+      - "Agora na trilha *$trilha* tem a seguinte programação: | $programacao"
     event: respond
 
   - name: erro-trilha
@@ -229,7 +227,6 @@ interactions:
       - que ótimo
     event: respond
 
-
   - name: bom-dia
     expect:
       - bom dia
@@ -243,7 +240,6 @@ interactions:
       - está melhor agora que você chegou $user
     event: respond
 
-
   - name: boa-tarde
     expect:
       - boa tarde
@@ -256,7 +252,6 @@ interactions:
       - $user já estava sentindo sua falta
     event: respond
 
-
   - name: boa-noite
     expect:
       - boa noite
@@ -266,7 +261,6 @@ interactions:
       - Boa noite $user
       - Está uma noite boa mesmo $user
     event: respond
-
 
   - name: quem-sou
     expect:
@@ -278,13 +272,9 @@ interactions:
       - como voce funciona
       - help
     answer:
-      - Bem, eu sou um chatbot experimental, não sei fazer muita coisa ainda
-      - mas tenho muita vontade de aprender.
-      - Eu sei falar sobre alguns assuntos como
-      - "- o TDC de Floripa"
-      - "- Rocket.Chat"
-      - "- Filosofia Robótica (!)"
-      - tem interesse em algum desses temas?
+      - >
+       Bem, eu sou um chatbot experimental, não sei fazer muita coisa ainda | mas tenho muita vontade de aprender.
+       Eu sei falar sobre alguns assuntos como | "- o TDC de Floripa" | "- Rocket.Chat" | "- Filosofia Robótica (!)" | tem interesse em algum desses temas?
     event: respond
 
   - name: como-sou


### PR DESCRIPTION
In this PR the attribute type of yaml file was removed and was add the other way to choose type of message.
For default if the answer would have more than one option. Will be chosen randomly only one.

To obtain the block effect you can define a symbol in yaml file, between string literal, using the
attribute: 'block_splitter'. This will be used to split the message and activate typing effect. Usage example:

trust: 0.8
block_splitter: '|'
interactions:
  - name: saudacao
    expect:
      - Hello
      - Hi
    answer:
      - Hello $user, i am fine and you? | I am happy to be here | =)
    event: respond

If the user does not want to define any symbol, the one used by default will be '|'.
